### PR TITLE
Fix edge case on server error code and error data

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <Product>Solnet.Serum</Product>
-        <Version>1.0.3</Version>
+        <Version>1.0.4</Version>
         <Copyright>Copyright 2021 &#169; Solnet</Copyright>
         <Authors>blockmountain</Authors>
         <PublisherName>blockmountain</PublisherName>

--- a/Solnet.Serum.Examples/Solnet.Serum.Examples.csproj
+++ b/Solnet.Serum.Examples/Solnet.Serum.Examples.csproj
@@ -12,8 +12,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Solnet.Rpc" Version="0.4.9" />
-      <PackageReference Include="Solnet.Wallet" Version="0.4.9" />
-      <PackageReference Include="Solnet.KeyStore" Version="0.4.9" />
+      <PackageReference Include="Solnet.Rpc" Version="0.4.11" />
+      <PackageReference Include="Solnet.Wallet" Version="0.4.11" />
+      <PackageReference Include="Solnet.KeyStore" Version="0.4.11" />
     </ItemGroup>
 </Project>

--- a/Solnet.Serum/MarketManager.cs
+++ b/Solnet.Serum/MarketManager.cs
@@ -952,13 +952,16 @@ namespace Solnet.Serum
 
             if (req.ServerErrorCode != 0)
             {
-                bool exists = req.ErrorData.TryGetValue("data", out object value);
-                if (!exists) return sigConf;
-                string elem = ((JsonElement)value).ToString();
-                if (elem == null) return sigConf;
-                SimulationLogs simulationLogs =
-                    JsonSerializer.Deserialize<SimulationLogs>(elem, _jsonSerializerOptions);
-                sigConf.ChangeState(simulationLogs);
+                if (req.ErrorData != null)
+                {
+                    bool exists = req.ErrorData.TryGetValue("data", out object value);
+                    if (!exists) return sigConf;
+                    string elem = ((JsonElement)value).ToString();
+                    if (elem == null) return sigConf;
+                    SimulationLogs simulationLogs =
+                        JsonSerializer.Deserialize<SimulationLogs>(elem, _jsonSerializerOptions);
+                    sigConf.ChangeState(simulationLogs);
+                }
 
                 return sigConf;
             }

--- a/Solnet.Serum/Solnet.Serum.csproj
+++ b/Solnet.Serum/Solnet.Serum.csproj
@@ -19,9 +19,9 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0.0" />
-        <PackageReference Include="Solnet.Programs" Version="0.4.9" />
-        <PackageReference Include="Solnet.Rpc" Version="0.4.9" />
-        <PackageReference Include="Solnet.Wallet" Version="0.4.9" />
+        <PackageReference Include="Solnet.Programs" Version="0.4.11" />
+        <PackageReference Include="Solnet.Rpc" Version="0.4.11" />
+        <PackageReference Include="Solnet.Wallet" Version="0.4.11" />
     </ItemGroup>
 
 


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Hotfix | No | Closes #52  |

## Problem

_What problem are you trying to solve?_

There was an edge case where `ServerErrorCode != 0` would be true but `ErrorData` would be null

## Solution

_How did you solve the problem?_

Added a null check on `ErrorData`