### PR TITLE
Adding referrer rebates accrued

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <Product>Solnet.Serum</Product>
-        <Version>1.0.3</Version>
+        <Version>1.0.4</Version>
         <Copyright>Copyright 2021 &#169; Solnet</Copyright>
         <Authors>blockmountain</Authors>
         <PublisherName>blockmountain</PublisherName>

--- a/Solnet.Serum.Test/SerumClientTest.cs
+++ b/Solnet.Serum.Test/SerumClientTest.cs
@@ -331,6 +331,7 @@ namespace Solnet.Serum.Test
             Assert.AreEqual("CuieVDEDtLo7FypA9SbLM9saXFdb1dsshEkyErMqkRQq", result.Owner.Key);
             Assert.AreEqual("9wFFyRfZBsuAha4YcuxcXLKwMxJR43S7fPfQLusDBzvT", result.Market.Key);
             Assert.AreEqual(30, result.Orders.Count);
+            Assert.AreEqual(0UL, result.ReferrerRebatesAccrued);
         }
 
         [TestMethod]


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | Yes | Closes #54  |

## Problem

_What problem are you trying to solve?_

open orders account was missing the referrer rebates accrued
open orders account deserialize method received a `ReadOnlySpan` but newest clients prefer the `byte[]` so it can be called via reflection