### PR TITLE
Changes to allow devnet usage, MarketManager defaults to mainnet

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <Product>Solnet.Serum</Product>
-        <Version>1.1.1</Version>
+        <Version>1.2.0</Version>
         <Copyright>Copyright 2021 &#169; Solnet</Copyright>
         <Authors>blockmountain</Authors>
         <PublisherName>blockmountain</PublisherName>

--- a/Solnet.Serum.Examples/ExampleExplorer.cs
+++ b/Solnet.Serum.Examples/ExampleExplorer.cs
@@ -10,7 +10,7 @@ namespace Solnet.Serum.Examples
     {
         public static void Main(string[] args)
         {
-            InstructionDecoder.Register(SerumProgram.ProgramIdKey, SerumProgram.Decode);
+            InstructionDecoder.Register(SerumProgram.MainNetProgramIdKeyV3, SerumProgram.Decode);
             List<Type> examples = Assembly.GetEntryAssembly()?.GetExportedTypes().Where(t => t.IsAssignableTo(typeof(IRunnableExample))).ToList();
             if (examples == null)
                 return;

--- a/Solnet.Serum.Examples/FindOpenOrdersAccounts.cs
+++ b/Solnet.Serum.Examples/FindOpenOrdersAccounts.cs
@@ -34,7 +34,7 @@ namespace Solnet.Serum.Examples
                 new MemCmp{ Offset = 45, Bytes = OwnerAddress }
             };
             RequestResult<List<AccountKeyPair>> accounts = 
-                RpcClient.GetProgramAccounts(SerumProgram.ProgramIdKey, dataSize: OpenOrdersAccount.Layout.SpanLength, memCmpList: filters);           
+                RpcClient.GetProgramAccounts(SerumProgram.MainNetProgramIdKeyV3, dataSize: OpenOrdersAccount.Layout.SpanLength, memCmpList: filters);           
             
             /* Print all of the found open orders accounts */
             foreach (AccountKeyPair account in accounts.Result)

--- a/Solnet.Serum.Examples/MarketManagerOrdersExample.cs
+++ b/Solnet.Serum.Examples/MarketManagerOrdersExample.cs
@@ -24,6 +24,7 @@ namespace Solnet.Serum.Examples
         private readonly ISerumClient _serumClient;
         private readonly IMarketManager _marketManager;
         private readonly Wallet.Wallet _wallet;
+        private readonly SerumProgram _serum;
         private OrderBook _orderBook;
         private List<Order> _bids;
         private List<Order> _asks;
@@ -35,6 +36,7 @@ namespace Solnet.Serum.Examples
             Console.WriteLine($"Initializing {ToString()}");
             // init stuff
             SolanaKeyStoreService keyStore = new ();
+            _serum = SerumProgram.CreateMainNet();
             
             // get the wallet
             _wallet = keyStore.RestoreKeystoreFromFile("/path/to/wallet.json");
@@ -133,7 +135,7 @@ namespace Solnet.Serum.Examples
 
             SignatureConfirmation sigConf = null;
 
-            TransactionInstruction settleIx = SerumProgram.SettleFunds(
+            TransactionInstruction settleIx = _serum.SettleFunds(
                 _marketManager.Market,
                 _marketManager.OpenOrdersAddress,
                 _wallet.Account,
@@ -144,7 +146,7 @@ namespace Solnet.Serum.Examples
             {
                 orders[i].ConvertOrderValues(_marketManager.BaseDecimals, _marketManager.QuoteDecimals, _marketManager.Market);
 
-                TransactionInstruction txInstruction = SerumProgram.NewOrderV3(
+                TransactionInstruction txInstruction = _serum.NewOrderV3(
                     _marketManager.Market,
                     _marketManager.OpenOrdersAddress,
                     orders[i].Side == Side.Buy ? 

--- a/Solnet.Serum.Test/InstructionDecoderTest.cs
+++ b/Solnet.Serum.Test/InstructionDecoderTest.cs
@@ -68,7 +68,7 @@ namespace Solnet.Serum.Test
         [ClassInitialize]
         public static void Setup(TestContext tc)
         {
-            InstructionDecoder.Register(SerumProgram.ProgramIdKey, SerumProgram.Decode);
+            InstructionDecoder.Register(SerumProgram.MainNetProgramIdKeyV3, SerumProgram.Decode);
         }
         
         [TestMethod]

--- a/Solnet.Serum.Test/MarketManagerTestBase.cs
+++ b/Solnet.Serum.Test/MarketManagerTestBase.cs
@@ -87,7 +87,7 @@ namespace Solnet.Serum.Test
         {
             rpcMock
                 .Setup(s => s.GetProgramAccountsAsync(
-                    It.Is<string>(s1 => s1 == SerumProgram.ProgramIdKey),
+                    It.Is<string>(s1 => s1 == SerumProgram.MainNetProgramIdKeyV3),
                     It.Is<Commitment>(c => c == commitment),
                     It.Is<int>(i => i == OpenOrdersAccount.Layout.SpanLength),
                     It.Is<List<MemCmp>>(

--- a/Solnet.Serum.Test/SerumProgramTest.cs
+++ b/Solnet.Serum.Test/SerumProgramTest.cs
@@ -327,7 +327,7 @@ namespace Solnet.Serum.Test
             var openOrders = wallet.GetAccount(3);
             var marketAuthority = wallet.GetAccount(5);
 
-            TransactionInstruction txInstruction = SerumProgram.InitOpenOrders(
+            TransactionInstruction txInstruction = serum.InitOpenOrders(
                 openOrders,
                 ownerAccount,
                 market.OwnAddress,

--- a/Solnet.Serum.Test/SerumProgramTest.cs
+++ b/Solnet.Serum.Test/SerumProgramTest.cs
@@ -82,6 +82,7 @@ namespace Solnet.Serum.Test
         [TestMethod]
         public void NewOrderV3Test()
         {
+            var serum = SerumProgram.CreateMainNet();
             var market = GetMarketAccount();
             var wallet = new Wallet.Wallet(MnemonicWords);
             var ownerAccount = wallet.GetAccount(1);
@@ -102,7 +103,7 @@ namespace Solnet.Serum.Test
             order.RawQuantity = 10000UL;
             order.MaxQuoteQuantity = 10000UL;
             
-            TransactionInstruction txInstruction = SerumProgram.NewOrderV3(
+            TransactionInstruction txInstruction = serum.NewOrderV3(
                 market, 
                 openOrders.PublicKey, 
                 payer.PublicKey, 
@@ -112,13 +113,14 @@ namespace Solnet.Serum.Test
             
             Assert.AreEqual(12, txInstruction.Keys.Count);
             CollectionAssert.AreEqual(ExpectedNewOrderV3Data, txInstruction.Data);
-            CollectionAssert.AreEqual(SerumProgram.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
+            CollectionAssert.AreEqual(serum.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
         }
         
         
         [TestMethod]
         public void EncodeNewOrderV3Test()
         {
+            var serum = SerumProgram.CreateMainNet();
             var market = GetMarketAccount();
             var wallet = new Wallet.Wallet(MnemonicWords);
             var ownerAccount = wallet.GetAccount(1);
@@ -147,6 +149,7 @@ namespace Solnet.Serum.Test
         [TestMethod]
         public void NewOrderV3SerumFeeDiscountTest()
         {
+            var serum = SerumProgram.CreateMainNet();
             var market = GetMarketAccount();
             var wallet = new Wallet.Wallet(MnemonicWords);
             var ownerAccount = wallet.GetAccount(1);
@@ -167,7 +170,7 @@ namespace Solnet.Serum.Test
             order.RawQuantity = 10000UL;
             order.MaxQuoteQuantity = 10000UL;
             
-            TransactionInstruction txInstruction = SerumProgram.NewOrderV3(
+            TransactionInstruction txInstruction = serum.NewOrderV3(
                 market, 
                 openOrders.PublicKey, 
                 payer.PublicKey, 
@@ -178,13 +181,14 @@ namespace Solnet.Serum.Test
 
             Assert.AreEqual(13, txInstruction.Keys.Count);
             CollectionAssert.AreEqual(ExpectedNewOrderV3SerumFeeData, txInstruction.Data);
-            CollectionAssert.AreEqual(SerumProgram.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
+            CollectionAssert.AreEqual(serum.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
         }
         
         
         [TestMethod]
         public void SettleFundsInvalidTest()
         {
+            var serum = SerumProgram.CreateMainNet();
             var market = GetMarketAccount();
             var wallet = new Wallet.Wallet(MnemonicWords);
             var ownerAccount = wallet.GetAccount(1);
@@ -193,7 +197,7 @@ namespace Solnet.Serum.Test
             var quoteW = wallet.GetAccount(4);
             var referrerPcWallet = wallet.GetAccount(4);
 
-            TransactionInstruction txInstruction = SerumProgram.SettleFunds(
+            TransactionInstruction txInstruction = serum.SettleFunds(
                 market,
                 openOrders,
                 ownerAccount, 
@@ -208,6 +212,7 @@ namespace Solnet.Serum.Test
         [TestMethod]
         public void SettleFundsTest()
         {
+            var serum = SerumProgram.CreateMainNet();
             var market = GetMarketV3Account();
             var wallet = new Wallet.Wallet(MnemonicWords);
             var ownerAccount = wallet.GetAccount(1);
@@ -216,7 +221,7 @@ namespace Solnet.Serum.Test
             var quoteW = wallet.GetAccount(4);
             var referrerPcWallet = wallet.GetAccount(4);
             
-            TransactionInstruction txInstruction = SerumProgram.SettleFunds(
+            TransactionInstruction txInstruction = serum.SettleFunds(
                 market,
                 openOrders,
                 ownerAccount, 
@@ -227,41 +232,41 @@ namespace Solnet.Serum.Test
             Assert.IsNotNull(txInstruction);
             Assert.AreEqual(10, txInstruction.Keys.Count);
             CollectionAssert.AreEqual(ExpectedSettleFundsData, txInstruction.Data);
-            CollectionAssert.AreEqual(SerumProgram.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
+            CollectionAssert.AreEqual(serum.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
         }
         
         [TestMethod]
         public void ConsumeEventsTest()
         {
+            var serum = SerumProgram.CreateMainNet();
             var market = GetMarketAccount();
             var wallet = new Wallet.Wallet(MnemonicWords);
-            var ownerAccount = wallet.GetAccount(1);
             var baseW = wallet.GetAccount(2);
             var openOrders = wallet.GetAccount(3);
             var quoteW = wallet.GetAccount(4);
 
-            TransactionInstruction txInstruction = SerumProgram.ConsumeEvents(
+            TransactionInstruction txInstruction = serum.ConsumeEvents(
                 new List<PublicKey>{openOrders}, 
-                market.OwnAddress,
-                ownerAccount,
+                market,
                 baseW, 
                 quoteW, 10);
             
             Assert.AreEqual(5, txInstruction.Keys.Count);
             CollectionAssert.AreEqual(ExpectedConsumeEventsData, txInstruction.Data);
-            CollectionAssert.AreEqual(SerumProgram.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
+            CollectionAssert.AreEqual(serum.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
         }
 
         [TestMethod]
         public void CancelOrderV2Test()
         {
+            var serum = SerumProgram.CreateMainNet();
             var market = GetMarketAccount();
             var wallet = new Wallet.Wallet(MnemonicWords);
             var ownerAccount = wallet.GetAccount(1);
             var openOrders = wallet.GetAccount(3);
 
             var orderId = new BigInteger(464876397401554404955348M);
-            TransactionInstruction txInstruction = SerumProgram.CancelOrderV2(
+            TransactionInstruction txInstruction = serum.CancelOrderV2(
                 market,
                 openOrders,
                 ownerAccount,
@@ -270,18 +275,19 @@ namespace Solnet.Serum.Test
             
             Assert.AreEqual(6, txInstruction.Keys.Count);
             CollectionAssert.AreEqual(ExpectedCancelOrderV2Data, txInstruction.Data);
-            CollectionAssert.AreEqual(SerumProgram.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
+            CollectionAssert.AreEqual(serum.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
         }
         
         [TestMethod]
         public void CancelOrderByClientIdV2Test()
         {
+            var serum = SerumProgram.CreateMainNet();
             var market = GetMarketAccount();
             var wallet = new Wallet.Wallet(MnemonicWords);
             var ownerAccount = wallet.GetAccount(1);
             var openOrders = wallet.GetAccount(3);
 
-            TransactionInstruction txInstruction = SerumProgram.CancelOrderByClientIdV2(
+            TransactionInstruction txInstruction = serum.CancelOrderByClientIdV2(
                 market,
                 openOrders,
                 ownerAccount,
@@ -289,30 +295,32 @@ namespace Solnet.Serum.Test
             
             Assert.AreEqual(6, txInstruction.Keys.Count);
             CollectionAssert.AreEqual(ExpectedCancelOrderByClientIdV2Data, txInstruction.Data);
-            CollectionAssert.AreEqual(SerumProgram.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
+            CollectionAssert.AreEqual(serum.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
         }
         
         [TestMethod]
         public void InitOpenOrdersTest()
         {
+            var serum = SerumProgram.CreateMainNet();
             var market = GetMarketAccount();
             var wallet = new Wallet.Wallet(MnemonicWords);
             var ownerAccount = wallet.GetAccount(1);
             var openOrders = wallet.GetAccount(3);
 
-            TransactionInstruction txInstruction = SerumProgram.InitOpenOrders(
+            TransactionInstruction txInstruction = serum.InitOpenOrders(
                 openOrders,
                 ownerAccount,
                 market.OwnAddress);
             
             Assert.AreEqual(4, txInstruction.Keys.Count);
             CollectionAssert.AreEqual(ExpectedInitOpenOrdersData, txInstruction.Data);
-            CollectionAssert.AreEqual(SerumProgram.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
+            CollectionAssert.AreEqual(serum.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
         }
         
         [TestMethod]
         public void InitOpenOrdersMarketAuthorityTest()
         {
+            var serum = SerumProgram.CreateMainNet();
             var market = GetMarketAccount();
             var wallet = new Wallet.Wallet(MnemonicWords);
             var ownerAccount = wallet.GetAccount(1);
@@ -327,19 +335,20 @@ namespace Solnet.Serum.Test
             
             Assert.AreEqual(5, txInstruction.Keys.Count);
             CollectionAssert.AreEqual(ExpectedInitOpenOrdersData, txInstruction.Data);
-            CollectionAssert.AreEqual(SerumProgram.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
+            CollectionAssert.AreEqual(serum.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
         }
         
         [TestMethod]
         public void CloseOpenOrdersTest()
         {
+            var serum = SerumProgram.CreateMainNet();
             var market = GetMarketAccount();
             var wallet = new Wallet.Wallet(MnemonicWords);
             var ownerAccount = wallet.GetAccount(1);
             var openOrders = wallet.GetAccount(3);
             var refundAccount = wallet.GetAccount(3);
 
-            TransactionInstruction txInstruction = SerumProgram.CloseOpenOrders(
+            TransactionInstruction txInstruction = serum.CloseOpenOrders(
                 openOrders,
                 ownerAccount,
                 refundAccount,
@@ -347,19 +356,20 @@ namespace Solnet.Serum.Test
             
             Assert.AreEqual(4, txInstruction.Keys.Count);
             CollectionAssert.AreEqual(ExpectedCloseOpenOrdersData, txInstruction.Data);
-            CollectionAssert.AreEqual(SerumProgram.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
+            CollectionAssert.AreEqual(serum.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
         }
         
         [TestMethod]
         public void PruneTest()
         {
+            var serum = SerumProgram.CreateMainNet();
             var market = GetMarketAccount();
             var wallet = new Wallet.Wallet(MnemonicWords);
             var ownerAccount = wallet.GetAccount(1);
             var pruneAuthority = wallet.GetAccount(2);
             var openOrders = wallet.GetAccount(3);
 
-            TransactionInstruction txInstruction = SerumProgram.Prune(
+            TransactionInstruction txInstruction = serum.Prune(
                 market,
                 pruneAuthority,
                 openOrders,
@@ -367,7 +377,7 @@ namespace Solnet.Serum.Test
             
             Assert.AreEqual(7, txInstruction.Keys.Count);
             CollectionAssert.AreEqual(ExpectedPruneData, txInstruction.Data);
-            CollectionAssert.AreEqual(SerumProgram.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
+            CollectionAssert.AreEqual(serum.ProgramIdKey.KeyBytes, txInstruction.ProgramId);
         }
     }
 }

--- a/Solnet.Serum/SerumProgram.cs
+++ b/Solnet.Serum/SerumProgram.cs
@@ -1,5 +1,7 @@
 using Solnet.Programs;
+using Solnet.Programs.Abstract;
 using Solnet.Programs.Utilities;
+using Solnet.Rpc;
 using Solnet.Rpc.Models;
 using Solnet.Rpc.Utilities;
 using Solnet.Serum.Models;
@@ -18,12 +20,17 @@ namespace Solnet.Serum
     /// https://github.com/project-serum/serum-dex/blob/master/dex/src/instruction.rs
     /// </remarks>
     /// </summary>
-    public class SerumProgram
+    public class SerumProgram : BaseProgram
     {
         /// <summary>
-        /// The Serum V3 Program key.
+        /// The Serum V3 Program key for <see cref="Cluster.MainNet"/>.
         /// </summary>
-        public static readonly PublicKey ProgramIdKey = new("9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin");
+        public static readonly PublicKey MainNetProgramIdKeyV3 = new("9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin");
+
+        /// <summary>
+        /// The Serum V3 Program key for <see cref="Cluster.DevNet"/>.
+        /// </summary>
+        public static readonly PublicKey DevNetProgramIdKeyV3 = new ("DESVgJVGajEgKGXhb6XmqDHGz3VjdgP7rEVESBgxmroY");
 
         /// <summary>
         /// The public key of the Serum token mint.
@@ -48,7 +55,26 @@ namespace Solnet.Serum
         /// <summary>
         /// The program's name.
         /// </summary>
-        private const string ProgramName = "Serum Program";
+        private const string DefaultProgramName = "Serum Program";
+
+        /// <summary>
+        /// Initialize the <see cref="SerumProgram"/> with the given program id key.
+        /// </summary>
+        /// <param name="programIdKey">The program id key.</param>
+        /// <param name="programName">The program name.</param>
+        public SerumProgram(PublicKey programIdKey, string programName) : base(programIdKey, programName) {}
+
+        /// <summary>
+        /// Initialize the <see cref="SerumProgram"/> for <see cref="Cluster.DevNet"/>.
+        /// </summary>
+        /// <returns>The <see cref="SerumProgram"/> instance.</returns>
+        public static SerumProgram CreateDevNet() => new SerumProgram(DevNetProgramIdKeyV3, DefaultProgramName);
+
+        /// <summary>
+        /// Initialize the <see cref="SerumProgram"/> for <see cref="Cluster.MainNet"/>.
+        /// </summary>
+        /// <returns>The <see cref="SerumProgram"/> instance.</returns>
+        public static SerumProgram CreateMainNet() => new SerumProgram(DevNetProgramIdKeyV3, DefaultProgramName);
 
         /// <summary>
         /// Initializes an instruction to create a new Order on Serum v3.
@@ -60,7 +86,7 @@ namespace Solnet.Serum
         /// <param name="order">The <see cref="Order"/> to place.</param>
         /// <param name="serumFeeDiscount">The public key of the SRM wallet for fee discount.</param>
         /// <returns>The transaction instruction.</returns>
-        public static TransactionInstruction NewOrderV3(Market market, PublicKey openOrdersAccount, 
+        public TransactionInstruction NewOrderV3(Market market, PublicKey openOrdersAccount, 
             PublicKey orderPayer, PublicKey openOrdersAccountOwner, Order order, PublicKey serumFeeDiscount = null)
             => NewOrderV3(market.OwnAddress, openOrdersAccount, market.RequestQueue, market.EventQueue, market.Bids,
                 market.Asks, orderPayer, openOrdersAccountOwner, market.BaseVault, market.QuoteVault,
@@ -141,7 +167,22 @@ namespace Solnet.Serum
         /// <param name="quoteWallet">The <see cref="PublicKey"/> of the quote wallet or token account.</param>
         /// <param name="referrerPcWallet">The <see cref="PublicKey"/> of the quote wallet or token account.</param>
         /// <returns>The transaction instruction.</returns>
-        public static TransactionInstruction SettleFunds(Market market, PublicKey openOrdersAccount, PublicKey owner,
+        public TransactionInstruction SettleFunds(Market market, PublicKey openOrdersAccount, PublicKey owner,
+            PublicKey baseWallet, PublicKey quoteWallet, PublicKey referrerPcWallet = null)
+            => SettleFunds(ProgramIdKey, market, openOrdersAccount, owner, baseWallet, quoteWallet, referrerPcWallet);
+
+        /// <summary>
+        /// Initializes an instruction to settle funds on Serum.
+        /// </summary>
+        /// <param name="programId">The <see cref="PublicKey"/> of the Serum Program associated with this market.</param>
+        /// <param name="market">The market we are trading on.</param>
+        /// <param name="openOrdersAccount">The <see cref="PublicKey"/> of the <see cref="OpenOrdersAccount"/> associated with this <see cref="Account"/> and <see cref="Market"/>.</param>
+        /// <param name="owner">The <see cref="PublicKey"/> of the account that owns the payer and the open orders account.</param>
+        /// <param name="baseWallet">The <see cref="PublicKey"/> of the coin wallet or token account.</param>
+        /// <param name="quoteWallet">The <see cref="PublicKey"/> of the quote wallet or token account.</param>
+        /// <param name="referrerPcWallet">The <see cref="PublicKey"/> of the quote wallet or token account.</param>
+        /// <returns>The transaction instruction.</returns>
+        public static TransactionInstruction SettleFunds(PublicKey programId, Market market, PublicKey openOrdersAccount, PublicKey owner,
             PublicKey baseWallet, PublicKey quoteWallet, PublicKey referrerPcWallet = null)
         {
             byte[] vaultSignerAddress = SerumProgramData.DeriveVaultSignerAddress(market);
@@ -167,7 +208,7 @@ namespace Solnet.Serum
 
             return new TransactionInstruction
             {
-                ProgramId = ProgramIdKey, Keys = keys, Data = SerumProgramData.EncodeSettleFundsData()
+                ProgramId = programId, Keys = keys, Data = SerumProgramData.EncodeSettleFundsData()
             };
         }
 
@@ -180,13 +221,14 @@ namespace Solnet.Serum
         /// <param name="pcAccount">The <see cref="PublicKey"/> of the price coin account.</param>
         /// <param name="limit">The maximum number of events to consume.</param>
         /// <returns>The transaction instruction.</returns>
-        public static TransactionInstruction ConsumeEvents(List<PublicKey> openOrdersAccounts,
+        public TransactionInstruction ConsumeEvents(List<PublicKey> openOrdersAccounts,
             Market market, PublicKey coinAccount, PublicKey pcAccount, ushort limit)
-            => ConsumeEvents(openOrdersAccounts, market.OwnAddress, market.EventQueue, coinAccount, pcAccount, limit);
+            => ConsumeEvents(ProgramIdKey, openOrdersAccounts, market.OwnAddress, market.EventQueue, coinAccount, pcAccount, limit);
 
         /// <summary>
         /// Initializes an instruction to consume events of a list of open orders accounts in a given market on Serum.
         /// </summary>
+        /// <param name="programId">The <see cref="PublicKey"/> of the Serum Program associated with this market.</param>
         /// <param name="openOrdersAccounts">A list of <see cref="PublicKey"/> of the <see cref="OpenOrdersAccount"/> associated with this <see cref="Account"/> and <see cref="Market"/>.</param>
         /// <param name="market">The <see cref="PublicKey"/> of the <see cref="Market"/> we are consuming events on.</param>
         /// <param name="eventQueue">The <see cref="PublicKey"/> of the <see cref="Market"/>'s event queue.</param>
@@ -194,7 +236,7 @@ namespace Solnet.Serum
         /// <param name="pcAccount">The <see cref="PublicKey"/> of the price coin account.</param>
         /// <param name="limit">The maximum number of events to consume.</param>
         /// <returns>The transaction instruction.</returns>
-        public static TransactionInstruction ConsumeEvents(List<PublicKey> openOrdersAccounts,
+        public static TransactionInstruction ConsumeEvents(PublicKey programId, List<PublicKey> openOrdersAccounts,
             PublicKey market, PublicKey eventQueue, PublicKey coinAccount, PublicKey pcAccount, ushort limit)
         {
             List<AccountMeta> keys = new();
@@ -206,7 +248,7 @@ namespace Solnet.Serum
 
             return new TransactionInstruction
             {
-                ProgramId = ProgramIdKey, Keys = keys, Data = SerumProgramData.EncodeConsumeEventsData(limit)
+                ProgramId = programId, Keys = keys, Data = SerumProgramData.EncodeConsumeEventsData(limit)
             };
         }
 
@@ -219,7 +261,7 @@ namespace Solnet.Serum
         /// <param name="side">The side of the order.</param>
         /// <param name="orderId">The order's id, fetched from a <see cref="OpenOrdersAccount"/>.</param>
         /// <returns>The transaction instruction.</returns>
-        public static TransactionInstruction CancelOrderV2(
+        public TransactionInstruction CancelOrderV2(
             Market market, PublicKey openOrdersAccount, PublicKey openOrdersAccountOwner, Side side, BigInteger orderId) 
             => CancelOrderV2(ProgramIdKey, market.OwnAddress, market.Bids, market.Asks, openOrdersAccount,
                 openOrdersAccountOwner, market.EventQueue, side, orderId);
@@ -265,7 +307,7 @@ namespace Solnet.Serum
         /// <param name="openOrdersAccountOwner">The <see cref="PublicKey"/> of the that owns the <see cref="OpenOrdersAccount"/>.</param>
         /// <param name="clientOrderId">The client's <c>orderId</c></param>
         /// <returns>The transaction instruction.</returns>
-        public static TransactionInstruction CancelOrderByClientIdV2(Market market, PublicKey openOrdersAccount,
+        public TransactionInstruction CancelOrderByClientIdV2(Market market, PublicKey openOrdersAccount,
             PublicKey openOrdersAccountOwner, ulong clientOrderId)
             => CancelOrderByClientIdV2(ProgramIdKey, market.OwnAddress, market.Bids, market.Asks, openOrdersAccount,
                 openOrdersAccountOwner, market.EventQueue, clientOrderId);
@@ -312,7 +354,7 @@ namespace Solnet.Serum
         /// <param name="destination">The <see cref="PublicKey"/> of the destination account.</param>
         /// <param name="market">The <see cref="PublicKey"/> of the market.</param>
         /// <returns>The transaction instruction.</returns>
-        public static TransactionInstruction CloseOpenOrders(PublicKey openOrdersAccount,
+        public TransactionInstruction CloseOpenOrders(PublicKey openOrdersAccount,
             PublicKey openOrdersAccountOwner, PublicKey destination, PublicKey market)
             => CloseOpenOrders(ProgramIdKey, openOrdersAccount, 
                 openOrdersAccountOwner, destination, market);
@@ -353,7 +395,7 @@ namespace Solnet.Serum
         /// <param name="market">The <see cref="PublicKey"/> of the market.</param>
         /// <param name="marketAuthority">The <see cref="PublicKey"/> of the market authority.</param>
         /// <returns>The transaction instruction.</returns>
-        public static TransactionInstruction InitOpenOrders(PublicKey openOrdersAccount,
+        public TransactionInstruction InitOpenOrders(PublicKey openOrdersAccount,
             PublicKey openOrdersAccountOwner, PublicKey market, PublicKey marketAuthority = null)
             => InitOpenOrders(ProgramIdKey, openOrdersAccount, openOrdersAccountOwner, market, marketAuthority);
 
@@ -396,7 +438,7 @@ namespace Solnet.Serum
         /// <param name="openOrdersAccount">The <see cref="PublicKey"/> of the <see cref="OpenOrdersAccount"/>.</param>
         /// <param name="openOrdersAccountOwner">The <see cref="PublicKey"/> of the <see cref="OpenOrdersAccount"/> owner.</param>
         /// <returns>The transaction instruction.</returns>
-        public static TransactionInstruction Prune(Market market, PublicKey pruneAuthority, PublicKey openOrdersAccount,
+        public TransactionInstruction Prune(Market market, PublicKey pruneAuthority, PublicKey openOrdersAccount,
             PublicKey openOrdersAccountOwner) => Prune(ProgramIdKey, market.OwnAddress, market.Bids,
             market.Asks, pruneAuthority, openOrdersAccount, openOrdersAccountOwner, market.EventQueue, ushort.MaxValue);
 
@@ -452,9 +494,9 @@ namespace Solnet.Serum
             
             DecodedInstruction decodedInstruction = new()
             {
-                PublicKey = ProgramIdKey,
+                PublicKey = MainNetProgramIdKeyV3,
                 InstructionName = SerumProgramInstructions.Names[instructionValue],
-                ProgramName = ProgramName,
+                ProgramName = DefaultProgramName,
                 Values = new Dictionary<string, object>(),
                 InnerInstructions = new List<DecodedInstruction>()
             };

--- a/Solnet.Serum/SerumProgramData.cs
+++ b/Solnet.Serum/SerumProgramData.cs
@@ -312,8 +312,9 @@ namespace Solnet.Serum
         /// </summary>
         /// <param name="market">The market.</param>
         /// <param name="vaultSignerNonce">The vault's signer nonce.</param>
+        /// <param name="programIdKey">The program id key.</param>
         /// <returns>The vault signer address.</returns>
-        public static byte[] DeriveVaultSignerAddress(PublicKey market, ulong vaultSignerNonce)
+        public static byte[] DeriveVaultSignerAddress(PublicKey market, ulong vaultSignerNonce, PublicKey programIdKey)
         {
             byte[] buffer = new byte[8];
             buffer.WriteU64(vaultSignerNonce, 0);
@@ -321,7 +322,7 @@ namespace Solnet.Serum
             List<byte[]> seeds = new() { market.KeyBytes, BitConverter.GetBytes(vaultSignerNonce) };
 
             bool success = AddressExtensions.TryCreateProgramAddress(seeds,
-                SerumProgram.ProgramIdKey.KeyBytes, out byte[] vaultSignerAddress);
+                programIdKey, out byte[] vaultSignerAddress);
 
             return !success ? null : vaultSignerAddress;
         }
@@ -330,8 +331,23 @@ namespace Solnet.Serum
         /// Derive the vault signer address for the given market.
         /// </summary>
         /// <param name="market">The market.</param>
+        /// <param name="programIdKey">The program id key.</param>
         /// <returns>The vault signer address.</returns>
         /// <exception cref="Exception">Throws exception when unable to derive the vault signer address.</exception>
-        public static byte[] DeriveVaultSignerAddress(Market market) => DeriveVaultSignerAddress(market.OwnAddress, market.VaultSignerNonce);
+        public static byte[] DeriveVaultSignerAddress(Market market, PublicKey programIdKey) 
+            => DeriveVaultSignerAddress(market.OwnAddress, market.VaultSignerNonce, programIdKey);
+
+        /// <summary>
+        /// Derive the vault signer address for the given market. 
+        /// </summary>
+        /// <remarks>
+        /// This method defaults to using <see cref="SerumProgram.MainNetProgramIdKeyV3"/> as the program id key. 
+        /// If you wish to derive the vault signer address using a different program id use <see cref="DeriveVaultSignerAddress(Market, PublicKey)"/>.
+        /// </remarks>
+        /// <param name="market">The market.</param>
+        /// <returns>The vault signer address.</returns>
+        /// <exception cref="Exception">Throws exception when unable to derive the vault signer address.</exception>
+        public static byte[] DeriveVaultSignerAddress(Market market)
+            => DeriveVaultSignerAddress(market.OwnAddress, market.VaultSignerNonce, SerumProgram.MainNetProgramIdKeyV3);
     }
 }


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Refactor| Yes| Closes #67 |

## Problem

_What problem are you trying to solve?_

There's no way to use serum on devnet
Lackluster for composability with Mango and other future program implementations

## Solution

_How did you solve the problem?_

Made the program inherit from `BaseProgram` defined in `Solnet.Programs.Abstract`

Cons: This feature introduces breaking changes with previous versions so will lead to a major version bump