### PR TITLE
Bumps Solnet version and prepares pipeline for separate net5 builds

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, net5 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, net5 ]
 
 jobs:
   build:
@@ -16,7 +16,7 @@ jobs:
         uses: cake-build/cake-action@v1
         with:
             script-path: build.cake
-            target: Pack
+            target: Report
             cake-bootstrap: true
       - name: Publish coverage report to coveralls.io
         uses: coverallsapp/github-action@v1.1.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master # Default release branch
-      - net # .NET 5 release branch
+      - net5 # .NET 5 release branch
 jobs:
   publish:
     name: build, pack & publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master # Default release branch
+      - net # .NET 5 release branch
 jobs:
   publish:
     name: build, pack & publish
@@ -11,6 +12,9 @@ jobs:
     steps:
       - name: Get the sources
         uses: actions/checkout@v2
+      - name: Extract release notes
+        run: |
+            git log --pretty=format:'%s' ${GITHUB_REF} | perl -pe 's| \(.*tag: v(\d+.\d+.\d+(-preview\d{3})?)(, .*?)*\)|\n## \1\n|g' > RELEASE-NOTES.txt
       - name: Run the build script
         uses: cake-build/cake-action@v1
         with:
@@ -39,7 +43,7 @@ jobs:
         with:
           tag_name: ${{ steps.publish_nuget.outputs.VERSION }}
           release_name: ${{ steps.publish_nuget.outputs.VERSION }}
-          body: ${{ steps.build_changelog.outputs.changelog }}
+          body_path: RELEASE-NOTES.txt
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       - name: Upload release assets

--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <Product>Solnet.Serum</Product>
-        <Version>1.3.0</Version>
+        <Version>1.4.0</Version>
         <Copyright>Copyright 2022 &#169; Solnet</Copyright>
         <Authors>blockmountain</Authors>
         <PublisherName>blockmountain</PublisherName>

--- a/Solnet.Serum.Examples/Solnet.Serum.Examples.csproj
+++ b/Solnet.Serum.Examples/Solnet.Serum.Examples.csproj
@@ -12,8 +12,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Solnet.Rpc" Version="0.6.0" />
-      <PackageReference Include="Solnet.Wallet" Version="0.6.0" />
-      <PackageReference Include="Solnet.KeyStore" Version="0.6.0" />
+      <PackageReference Include="Solnet.Rpc" Version="0.6.1" />
+      <PackageReference Include="Solnet.Wallet" Version="0.6.1" />
+      <PackageReference Include="Solnet.KeyStore" Version="0.6.1" />
     </ItemGroup>
 </Project>

--- a/Solnet.Serum.sln
+++ b/Solnet.Serum.sln
@@ -24,6 +24,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.github\workflows\publish.yml = .github\workflows\publish.yml
 		PULL_REQUEST_TEMPLATE.md = PULL_REQUEST_TEMPLATE.md
 		README.md = README.md
+		RELEASE-NOTES.txt = RELEASE-NOTES.txt
 		SharedBuildProperties.props = SharedBuildProperties.props
 		Solnet.Serum.sln.DotSettings = Solnet.Serum.sln.DotSettings
 	EndProjectSection

--- a/Solnet.Serum/SerumProgram.cs
+++ b/Solnet.Serum/SerumProgram.cs
@@ -185,9 +185,9 @@ namespace Solnet.Serum
         public static TransactionInstruction SettleFunds(PublicKey programId, Market market, PublicKey openOrdersAccount, PublicKey owner,
             PublicKey baseWallet, PublicKey quoteWallet, PublicKey referrerPcWallet = null)
         {
-            byte[] vaultSignerAddress = SerumProgramData.DeriveVaultSignerAddress(market);
+            PublicKey vaultSigner = SerumProgramData.DeriveVaultSignerAddress(market);
 
-            if (vaultSignerAddress == null)
+            if (vaultSigner == null)
                 return null;
 
             List<AccountMeta> keys = new()
@@ -199,7 +199,7 @@ namespace Solnet.Serum
                 AccountMeta.Writable(market.QuoteVault, false),
                 AccountMeta.Writable(baseWallet, false),
                 AccountMeta.Writable(quoteWallet, false),
-                AccountMeta.ReadOnly(new PublicKey(vaultSignerAddress), false),
+                AccountMeta.ReadOnly(vaultSigner, false),
                 AccountMeta.ReadOnly(TokenProgram.ProgramIdKey, false)
             };
             

--- a/Solnet.Serum/SerumProgramData.cs
+++ b/Solnet.Serum/SerumProgramData.cs
@@ -314,17 +314,17 @@ namespace Solnet.Serum
         /// <param name="vaultSignerNonce">The vault's signer nonce.</param>
         /// <param name="programIdKey">The program id key.</param>
         /// <returns>The vault signer address.</returns>
-        public static byte[] DeriveVaultSignerAddress(PublicKey market, ulong vaultSignerNonce, PublicKey programIdKey)
+        public static PublicKey DeriveVaultSignerAddress(PublicKey market, ulong vaultSignerNonce, PublicKey programIdKey)
         {
             byte[] buffer = new byte[8];
             buffer.WriteU64(vaultSignerNonce, 0);
 
             List<byte[]> seeds = new() { market.KeyBytes, BitConverter.GetBytes(vaultSignerNonce) };
 
-            bool success = AddressExtensions.TryCreateProgramAddress(seeds,
-                programIdKey, out byte[] vaultSignerAddress);
+            var _ = PublicKey.TryCreateProgramAddress(seeds,
+                programIdKey, out PublicKey vaultSignerAddress);
 
-            return !success ? null : vaultSignerAddress;
+            return vaultSignerAddress;
         }
 
         /// <summary>
@@ -334,7 +334,7 @@ namespace Solnet.Serum
         /// <param name="programIdKey">The program id key.</param>
         /// <returns>The vault signer address.</returns>
         /// <exception cref="Exception">Throws exception when unable to derive the vault signer address.</exception>
-        public static byte[] DeriveVaultSignerAddress(Market market, PublicKey programIdKey) 
+        public static PublicKey DeriveVaultSignerAddress(Market market, PublicKey programIdKey) 
             => DeriveVaultSignerAddress(market.OwnAddress, market.VaultSignerNonce, programIdKey);
 
         /// <summary>
@@ -347,7 +347,7 @@ namespace Solnet.Serum
         /// <param name="market">The market.</param>
         /// <returns>The vault signer address.</returns>
         /// <exception cref="Exception">Throws exception when unable to derive the vault signer address.</exception>
-        public static byte[] DeriveVaultSignerAddress(Market market)
+        public static PublicKey DeriveVaultSignerAddress(Market market)
             => DeriveVaultSignerAddress(market.OwnAddress, market.VaultSignerNonce, SerumProgram.MainNetProgramIdKeyV3);
     }
 }

--- a/Solnet.Serum/Solnet.Serum.csproj
+++ b/Solnet.Serum/Solnet.Serum.csproj
@@ -19,9 +19,9 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0.0" />
-        <PackageReference Include="Solnet.Programs" Version="0.6.0" />
-        <PackageReference Include="Solnet.Rpc" Version="0.6.0" />
-        <PackageReference Include="Solnet.Wallet" Version="0.6.0" />
+        <PackageReference Include="Solnet.Programs" Version="0.6.1" />
+        <PackageReference Include="Solnet.Rpc" Version="0.6.1" />
+        <PackageReference Include="Solnet.Wallet" Version="0.6.1" />
     </ItemGroup>
 
 


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Tooling/Refactor | Yes| Closes #72 |

## Description

Bumps Solnet version to v0.6.1
Fixes changes to namespaces due to refactoring in PDA generation
Prepares pipeline for separate net5 builds