### PR TITLE
Fix program id on `CreateMainNet`

### DIFF
--- a/SharedBuildProperties.props
+++ b/SharedBuildProperties.props
@@ -2,7 +2,7 @@
          xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <Product>Solnet.Serum</Product>
-        <Version>5.0.1</Version>
+        <Version>5.0.1.1</Version>
         <Copyright>Copyright 2022 &#169; Solnet</Copyright>
         <Authors>blockmountain</Authors>
         <PublisherName>blockmountain</PublisherName>

--- a/Solnet.Serum.Test/SerumProgramTest.cs
+++ b/Solnet.Serum.Test/SerumProgramTest.cs
@@ -80,6 +80,22 @@ namespace Solnet.Serum.Test
         }
 
         [TestMethod]
+        public void CreateMainNet()
+        {
+            var serum = SerumProgram.CreateMainNet();
+
+            Assert.AreEqual(serum.ProgramIdKey, SerumProgram.MainNetProgramIdKeyV3);
+        }
+
+        [TestMethod]
+        public void CreateDevNet()
+        {
+            var serum = SerumProgram.CreateDevNet();
+
+            Assert.AreEqual(serum.ProgramIdKey, SerumProgram.DevNetProgramIdKeyV3);
+        }
+
+        [TestMethod]
         public void NewOrderV3Test()
         {
             var serum = SerumProgram.CreateMainNet();

--- a/Solnet.Serum/SerumProgram.cs
+++ b/Solnet.Serum/SerumProgram.cs
@@ -74,7 +74,7 @@ namespace Solnet.Serum
         /// Initialize the <see cref="SerumProgram"/> for <see cref="Cluster.MainNet"/>.
         /// </summary>
         /// <returns>The <see cref="SerumProgram"/> instance.</returns>
-        public static SerumProgram CreateMainNet() => new SerumProgram(DevNetProgramIdKeyV3, DefaultProgramName);
+        public static SerumProgram CreateMainNet() => new SerumProgram(MainNetProgramIdKeyV3, DefaultProgramName);
 
         /// <summary>
         /// Initializes an instruction to create a new Order on Serum v3.


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Hotfix | Yes | #82   |

## Problem

_What problem are you trying to solve?_

When the refactoring for the new program structures was done somehow the `CreateMainNet` method kept the wrong program id and no test was covering it

## Solution

_How did you solve the problem?_

Changed the program id and added new tests for the two methods
